### PR TITLE
feat: Add a MailChimp signup form, sort of.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -60,6 +60,13 @@ module.exports = {
         },
       },
     },
+    {
+      resolve: 'gatsby-plugin-mailchimp',
+      options: {
+        endpoint:
+          'https://octopusthink.us4.list-manage.com/subscribe/post?u=dec5c2d889866b4c67a61ff55&amp;id=cd3b5cf599',
+      },
+    },
   ],
   mapping: {
     'MarkdownRemark.fields.authors': 'AuthorsYaml',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5093,6 +5093,11 @@
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.3.tgz",
       "integrity": "sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg=="
     },
+    "email-validator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -7839,6 +7844,15 @@
         "lodash": "^4.17.11"
       }
     },
+    "gatsby-plugin-mailchimp": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-mailchimp/-/gatsby-plugin-mailchimp-5.1.2.tgz",
+      "integrity": "sha512-x3tOj4cl1QMBJUHKd7/ZxFhUU8BW0yt1NkgtCfT9kyywFNS4TCPjW/niQLhl1ze4HUVOu+MGbGgDbA+OMmqL8g==",
+      "requires": {
+        "email-validator": "^2.0.4",
+        "jsonp": "^0.2.1"
+      }
+    },
     "gatsby-plugin-page-creator": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.7.tgz",
@@ -10063,6 +10077,29 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
+      "requires": {
+        "debug": "^2.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "jsontoxml": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gatsby": "^2.13.24",
     "gatsby-plugin-emotion": "^4.1.2",
     "gatsby-plugin-favicon": "^3.1.6",
+    "gatsby-plugin-mailchimp": "^5.1.2",
     "gatsby-plugin-react-helmet": "^3.1.2",
     "gatsby-plugin-react-svg": "^2.1.2",
     "gatsby-plugin-sitemap": "^2.2.9",

--- a/src/components/NewsletterSignupForm/index.js
+++ b/src/components/NewsletterSignupForm/index.js
@@ -1,0 +1,56 @@
+import { Button, Icon, TextField } from '@octopusthink/nautilus';
+import React, { useRef, useState } from 'react';
+import { css } from '@emotion/core';
+import addToMailchimp from 'gatsby-plugin-mailchimp';
+
+import theme from '../../../config/theme';
+
+const NewsletterSignupForm = () => {
+  const emailRef = useRef();
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+
+  const onChange = () => {
+    setErrorMessage(null);
+    setSuccessMessage(null);
+  };
+
+  const submitForm = async (event) => {
+    event.preventDefault();
+
+    if (emailRef && emailRef.current && emailRef.current.value) {
+      try {
+        const response = await addToMailchimp(emailRef.current.value);
+        if (response.result === 'success') {
+          setErrorMessage(null);
+          setSuccessMessage(response.msg);
+        } else {
+          setErrorMessage(response.msg);
+          setSuccessMessage(null);
+        }
+        console.log('email success', response);
+      } catch (error) {
+        console.error('email error', error);
+        setErrorMessage(response.msg);
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={submitForm}>
+      {successMessage && <p>Success! {successMessage}</p>}
+      <TextField
+        error={errorMessage}
+        onChange={onChange}
+        label="Email"
+        type="email"
+        name="email"
+        autoComplete="email"
+        ref={emailRef}
+      />
+      <Button onClick={submitForm}>Sign up</Button>
+    </form>
+  );
+};
+
+export default NewsletterSignupForm;

--- a/src/templates/Page.js
+++ b/src/templates/Page.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { markdown } from '../utils/markdown';
 
 import App from './App';
+import NewsletterSignupForm from '../components/NewsletterSignupForm';
 import PageBody from '../components/PageBody';
 import PageHeader from '../components/PageHeader';
 import PageWrapper from '../components/PageWrapper';
@@ -24,7 +25,10 @@ export const Page = (props) => {
       <SEO title={title} description={description} />
       <PageWrapper>
         <PageHeader pageTitle={title} summary={summary} description={description} />
-        <PageBody>{content}</PageBody>
+        <PageBody>
+          <NewsletterSignupForm />
+          {content}
+        </PageBody>
       </PageWrapper>
     </App>
   );


### PR DESCRIPTION
@tofumatt I'll need your help with this, since it's more complex than expected.

https://www.gatsbyjs.org/packages/gatsby-plugin-mailchimp/

Here's what we need to do here:

- Normalise/fine-tune/make-nice error + success messages.
- Probably add some text and whatnot.
- Add form to the contact page and the "hello" blog post, ideally. (https://www.gatsbyjs.org/docs/mdx/)

For launch/pre-launch we can probably just link to an external form, at least for the blog post. For the contact page, maybe it'd make sense to make it a component-component instead of a Markdown file for now.  Since I'll be doing some custom work on the top-level pages, we may wind up wanting them to use HTML anyway, so the whole MDX thing might be moot. 🤷‍♀️