### PR TITLE
chore: skip test run on master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,10 @@ name: Publish Website
 on:
   push:
     branches:
-      - "!*"
+      - '!*'
       - master
   schedule:
-    - cron:  '45 9 * * *'
+    - cron: '45 9 * * *'
 
 jobs:
   publish:
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v1
       - name: Install dependencies
         run: npm install
+      - name: Lint JS
+        run: npm run lint
       - name: Build website
         run: npm run build
       - name: Deploy to GitHub Pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,14 +2,9 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - "!*"
-      - "!gh-pages"
-      - "master"
   pull_request:
     branches:
-      - "*"
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
Skips the "test" action on pushes to `master`, as the build is already run in the publish action.