### PR TITLE
fix: Do not use relative import paths

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,12 @@ module.exports = {
   },
   plugins: [
     {
+      resolve: `gatsby-plugin-layout`,
+      options: {
+        component: require.resolve(`./src/components/NautilusWrapper`),
+      },
+    },
+    {
       resolve: 'gatsby-plugin-feed',
       options: {
         query: `

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,6 +7,9 @@ const { singular } = require('pluralize');
 
 const config = require('./config');
 
+const projectPath = path.resolve(fs.realpathSync(process.cwd()), '.');
+const srcPath = path.resolve(fs.realpathSync(process.cwd()), 'src');
+
 const { postsPerPage, useDatesInSlugs } = config;
 
 // Gatsby Integers only support 32-bit integers, so this uses that as the
@@ -306,4 +309,13 @@ const createPages = async ({ actions, graphql }) => {
   makePages({ actions, pages });
 };
 
-module.exports = { createPages, onCreateNode };
+const onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    resolve: {
+      extensions: ['.mjs', '.jsx', '.js', '.json'],
+      modules: [srcPath, projectPath, 'node_modules'],
+    },
+  });
+};
+
+module.exports = { createPages, onCreateNode, onCreateWebpackConfig };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9008,6 +9008,24 @@
         }
       }
     },
+    "gatsby-plugin-layout": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-layout/-/gatsby-plugin-layout-1.1.10.tgz",
+      "integrity": "sha512-FUvwZyH7YN1L1LUXQiUbqy/YfU7iC4ZfZZ5jD8btCO3yD2h3s6C1c8V35l7Yte9MAVBNGa+0ztKsqLLKKw1g7g==",
+      "requires": {
+        "@babel/runtime": "^7.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "gatsby-plugin-matomo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gatsby-plugin-emotion": "^4.1.9",
     "gatsby-plugin-favicon": "^3.1.6",
     "gatsby-plugin-feed": "^2.3.15",
+    "gatsby-plugin-layout": "^1.1.10",
     "gatsby-plugin-matomo": "^0.7.2",
     "gatsby-plugin-react-helmet": "^3.1.10",
     "gatsby-plugin-react-svg": "^2.1.2",

--- a/src/components/AboutContent/index.js
+++ b/src/components/AboutContent/index.js
@@ -2,8 +2,8 @@ import { Button, Heading, List, Paragraph, Strong } from '@octopusthink/nautilus
 import { useStaticQuery, graphql } from 'gatsby';
 import React from 'react';
 
-import IllustratedPoint from '../IllustratedPoint';
-import Panel from '../Panel';
+import IllustratedPoint from 'components/IllustratedPoint';
+import Panel from 'components/Panel';
 
 const ServicesContent = () => {
   const staticData = useStaticQuery(graphql`

--- a/src/components/AuthorByline/index.js
+++ b/src/components/AuthorByline/index.js
@@ -1,11 +1,11 @@
-import { Heading, Paragraph, Tags } from '@octopusthink/nautilus';
+import { Heading, Paragraph, Tags, useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import { css } from '@emotion/core';
 
-import theme from '../../../config/theme';
-
 const AuthorByline = (props) => {
   const { alt, avatar, children, name } = props;
+  const theme = useTheme();
+
   return (
     <div
       css={css`

--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -1,9 +1,7 @@
-import { interfaceUI } from '@octopusthink/nautilus';
+import { interfaceUI, useTheme } from '@octopusthink/nautilus';
 import React, { forwardRef, useMemo, useState } from 'react';
 import { css } from '@emotion/core';
 import shortid from 'shortid';
-
-import theme from '../../../config/theme';
 
 export const Checkbox = forwardRef((props, ref) => {
   const { children, id, ...otherProps } = props;
@@ -11,6 +9,7 @@ export const Checkbox = forwardRef((props, ref) => {
   const inputId = useMemo(() => {
     return id || generatedId;
   }, [generatedId, id]);
+  const theme = useTheme();
 
   return (
     <div

--- a/src/components/ContactContent/index.js
+++ b/src/components/ContactContent/index.js
@@ -2,10 +2,10 @@ import { Heading, Link, Paragraph, useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import { css } from '@emotion/core';
 
-import Panel from '../Panel';
-import QuoteForm from '../QuoteForm';
-import NewsletterSignupForm from '../NewsletterSignupForm';
-import SocialMediaLinks from '../SocialMediaLinks';
+import Panel from 'components/Panel';
+import QuoteForm from 'components/QuoteForm';
+import NewsletterSignupForm from 'components/NewsletterSignupForm';
+import SocialMediaLinks from 'components/SocialMediaLinks';
 
 const ContactContent = () => {
   const theme = useTheme();

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -4,14 +4,14 @@ import Img from 'gatsby-image';
 import React from 'react';
 import { css } from '@emotion/core';
 
-import IllustratedPoint from '../IllustratedPoint';
-import AccessibilityIllustration from '../../../static/illustrations/accessibility.svg';
-import StrategyIllustration from '../../../static/illustrations/strategy.svg';
-import AppIllustration from '../../../static/illustrations/app.svg';
-import WebIllustration from '../../../static/illustrations/web.svg';
-import ProductIllustration from '../../../static/illustrations/product.svg';
-import VisualIllustration from '../../../static/illustrations/visual.svg';
-import Panel from '../Panel';
+import IllustratedPoint from 'components/IllustratedPoint';
+import Panel from 'components/Panel';
+import AccessibilityIllustration from 'static/illustrations/accessibility.svg';
+import StrategyIllustration from 'static/illustrations/strategy.svg';
+import AppIllustration from 'static/illustrations/app.svg';
+import WebIllustration from 'static/illustrations/web.svg';
+import ProductIllustration from 'static/illustrations/product.svg';
+import VisualIllustration from 'static/illustrations/visual.svg';
 
 const HomepageContent = () => {
   const staticData = useStaticQuery(graphql`

--- a/src/components/NautilusWrapper/index.js
+++ b/src/components/NautilusWrapper/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Nautilus from '@octopusthink/nautilus';
+import { Link } from 'gatsby';
+
+import theme from 'config/theme';
+
+const NautilusWrapper = (props) => {
+  const { children } = props;
+
+  return (
+    <Nautilus theme={theme} config={{ LinkComponent: Link }}>
+      {children}
+    </Nautilus>
+  );
+};
+
+export default NautilusWrapper;

--- a/src/components/NavigationMenu/index.js
+++ b/src/components/NavigationMenu/index.js
@@ -1,14 +1,14 @@
-import { Icon, VisuallyHidden } from '@octopusthink/nautilus';
+import { Icon, VisuallyHidden, useTheme } from '@octopusthink/nautilus';
 import React, { useState } from 'react';
 import { css, Global } from '@emotion/core';
 import useEventListener from '@use-it/event-listener';
 
-import NavigationMenuItem from '../NavigationMenuItem';
-import theme from '../../../config/theme';
+import NavigationMenuItem from 'components/NavigationMenuItem';
 
 const NavigationMenu = () => {
   // Menu is hidden by default on mobile.
   const [hideMenu, setHideMenu] = useState(true);
+  const theme = useTheme();
   const toggleMenu = () => {
     setHideMenu(!hideMenu);
   };

--- a/src/components/PageBody/index.js
+++ b/src/components/PageBody/index.js
@@ -1,10 +1,11 @@
+import { useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import { css } from '@emotion/core';
 
-import theme from '../../../config/theme';
-
 const PageBody = (props) => {
   const { children } = props;
+  const theme = useTheme();
+
   return (
     <section
       css={css`

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -1,12 +1,13 @@
-import { PageTitle, Paragraph } from '@octopusthink/nautilus';
+import { PageTitle, Paragraph, useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import { css } from '@emotion/core';
 
-import theme from '../../../config/theme';
-import Watermark from '../../../static/watermark.svg';
+import Watermark from 'static/watermark.svg';
 
 const PageHeader = (props) => {
   const { children, metadata, pageTitle, summary, summaryExtra } = props;
+  const theme = useTheme();
+
   return (
     <header
       css={css`

--- a/src/components/Panel/index.js
+++ b/src/components/Panel/index.js
@@ -1,9 +1,9 @@
+import { useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import { css } from '@emotion/core';
 
-import theme from '../../../config/theme';
-
 const Panel = (props) => {
+  const theme = useTheme();
   const { children, className, dark, grid, gridSmall } = props;
 
   const panelBackground = dark ? theme.colors.neutral.black : theme.colors.neutral.white;

--- a/src/components/PostCard/index.js
+++ b/src/components/PostCard/index.js
@@ -6,15 +6,16 @@ import {
   Tags,
   VisuallyHidden,
   metadata,
+  useTheme,
 } from '@octopusthink/nautilus';
 import React from 'react';
 import { css } from '@emotion/core';
 import dayjs from 'dayjs';
 
-import config from '../../../config';
-import theme from '../../../config/theme';
+import config from 'config';
 
 const PostCard = (props) => {
+  const theme = useTheme();
   const { date, readingTime, slug, summary, title } = props;
   const formattedDate = dayjs(date).format(config.dateFormat);
 

--- a/src/components/QuoteForm/index.js
+++ b/src/components/QuoteForm/index.js
@@ -5,15 +5,17 @@ import {
   Paragraph,
   TextField,
   interfaceUI,
+  useTheme,
 } from '@octopusthink/nautilus';
 import React, { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/core';
 import EmailValidator from 'email-validator';
 
-import theme from '../../../config/theme';
-import Checkbox from '../Checkbox'; // Move this to Nautilus!
+import Checkbox from 'components/Checkbox'; // Move this to Nautilus!
 
 const QuoteForm = () => {
+  const theme = useTheme();
+
   const firstCheckboxRef = useRef();
   const stepRefs = {};
   stepRefs[1] = useRef();

--- a/src/components/ServicesContent/index.js
+++ b/src/components/ServicesContent/index.js
@@ -11,15 +11,15 @@ import {
 import React from 'react';
 import { css } from '@emotion/core';
 
-import IllustratedPoint from '../IllustratedPoint';
-import AccessibilityIllustration from '../../../static/illustrations/accessibility.svg';
-import StrategyIllustration from '../../../static/illustrations/strategy.svg';
-import AppIllustration from '../../../static/illustrations/app.svg';
-import WebIllustration from '../../../static/illustrations/web.svg';
-import ProductIllustration from '../../../static/illustrations/product.svg';
-import VisualIllustration from '../../../static/illustrations/visual.svg';
-import Panel from '../Panel';
-import Testimonial from '../Testimonial';
+import IllustratedPoint from 'components/IllustratedPoint';
+import Panel from 'components/Panel';
+import Testimonial from 'components/Testimonial';
+import AccessibilityIllustration from 'static/illustrations/accessibility.svg';
+import StrategyIllustration from 'static/illustrations/strategy.svg';
+import AppIllustration from 'static/illustrations/app.svg';
+import WebIllustration from 'static/illustrations/web.svg';
+import ProductIllustration from 'static/illustrations/product.svg';
+import VisualIllustration from 'static/illustrations/visual.svg';
 
 const ServicesContent = () => {
   const theme = useTheme();

--- a/src/components/SiteFooter/index.js
+++ b/src/components/SiteFooter/index.js
@@ -2,10 +2,10 @@ import { css } from '@emotion/core';
 import { Button, Link, Paragraph, metadata, useTheme } from '@octopusthink/nautilus';
 import React, { useRef } from 'react';
 
-import Logo from '../../../static/octopusthink.svg';
-import NewsletterSignupForm from '../NewsletterSignupForm';
-import SiteMap from '../SiteMap';
-import SocialMediaLinks from '../SocialMediaLinks';
+import NewsletterSignupForm from 'components/NewsletterSignupForm';
+import SiteMap from 'components/SiteMap';
+import SocialMediaLinks from 'components/SocialMediaLinks';
+import Logo from 'static/octopusthink.svg';
 
 const SiteFooter = () => {
   const emailRef = useRef();

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -2,8 +2,8 @@ import { Link, SkipLink, useTheme } from '@octopusthink/nautilus';
 import React, { useState } from 'react';
 import { css } from '@emotion/core';
 
-import Logo from '../../../static/octopusthink.svg';
-import NavigationMenu from '../NavigationMenu';
+import NavigationMenu from 'components/NavigationMenu';
+import Logo from 'static/octopusthink.svg';
 
 const SiteHeader = () => {
   const [onHomepage, setOnHomepage] = useState();

--- a/src/components/SiteMap/index.js
+++ b/src/components/SiteMap/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
 
-import ListLink from '../ListLink';
+import ListLink from 'components/ListLink';
 
 const SiteMap = (props) => {
   const { className } = props;

--- a/src/components/SocialMediaLinks/index.js
+++ b/src/components/SocialMediaLinks/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/core';
 
-import ListLink from '../ListLink';
+import ListLink from 'components/ListLink';
 
 const SocialMediaLinks = (props) => {
   const { className } = props;

--- a/src/templates/About.js
+++ b/src/templates/About.js
@@ -1,11 +1,11 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import App from './App';
-import AboutContent from '../components/AboutContent';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import AboutContent from 'components/AboutContent';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const Page = (props) => {
   const { data } = props;

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -4,9 +4,9 @@ import { Link } from 'gatsby';
 import React from 'react';
 import 'typeface-inter';
 
-import SiteHeader from '../components/SiteHeader';
-import SiteFooter from '../components/SiteFooter';
-import theme from '../../config/theme';
+import SiteHeader from 'components/SiteHeader';
+import SiteFooter from 'components/SiteFooter';
+import theme from 'config/theme';
 
 export const App = (props) => {
   const { children } = props;

--- a/src/templates/App.js
+++ b/src/templates/App.js
@@ -1,18 +1,17 @@
 import { css, Global } from '@emotion/core';
-import Nautilus from '@octopusthink/nautilus';
-import { Link } from 'gatsby';
+import { useTheme } from '@octopusthink/nautilus';
 import React from 'react';
 import 'typeface-inter';
 
 import SiteHeader from 'components/SiteHeader';
 import SiteFooter from 'components/SiteFooter';
-import theme from 'config/theme';
 
 export const App = (props) => {
+  const theme = useTheme();
   const { children } = props;
 
   return (
-    <Nautilus theme={theme} config={{ LinkComponent: Link }}>
+    <React.Fragment>
       <Global
         styles={css`
           body {
@@ -69,7 +68,7 @@ export const App = (props) => {
       <SiteHeader />
       <main id="content">{children}</main>
       <SiteFooter />
-    </Nautilus>
+    </React.Fragment>
   );
 };
 

--- a/src/templates/Blog/Post.js
+++ b/src/templates/Blog/Post.js
@@ -1,23 +1,23 @@
-import { Link, Tags, metadata } from '@octopusthink/nautilus';
+import { Link, Tags, metadata, useTheme } from '@octopusthink/nautilus';
 import { graphql } from 'gatsby';
 import React, { Fragment } from 'react';
 import { css } from '@emotion/core';
-
 import dayjs from 'dayjs';
-import { markdown } from '../../utils/markdown';
 
-import App from '../App';
-import AuthorByline from '../../components/AuthorByline';
-import PageBody from '../../components/PageBody';
-import PageFooter from '../../components/PageFooter';
-import PageHeader from '../../components/PageHeader';
-import PageWrapper from '../../components/PageWrapper';
-import SequentialLink from '../../components/SequentialLink';
-import SEO from '../../components/SEO';
-import config from '../../../config';
-import theme from '../../../config/theme';
+import AuthorByline from 'components/AuthorByline';
+import PageBody from 'components/PageBody';
+import PageFooter from 'components/PageFooter';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SequentialLink from 'components/SequentialLink';
+import SEO from 'components/SEO';
+import config from 'config';
+import App from 'templates/App';
+import { markdown } from 'utils/markdown';
 
 export const BlogPost = (props) => {
+  const theme = useTheme();
+
   const { data, pageContext } = props;
   const { post } = data;
 

--- a/src/templates/Blog/Tag.js
+++ b/src/templates/Blog/Tag.js
@@ -1,11 +1,11 @@
 import { graphql } from 'gatsby';
 import React, { Fragment } from 'react';
 
-import App from '../App';
-import PageHeader from '../../components/PageHeader';
-import PageBody from '../../components/PageBody';
-import PostCard from '../../components/PostCard';
-import SEO from '../../components/SEO';
+import PageHeader from 'components/PageHeader';
+import PageBody from 'components/PageBody';
+import PostCard from 'components/PostCard';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const BlogTags = (props) => {
   const { data, pageContext } = props;

--- a/src/templates/Blog/index.js
+++ b/src/templates/Blog/index.js
@@ -2,11 +2,11 @@ import { Link, List } from '@octopusthink/nautilus';
 import { graphql } from 'gatsby';
 import React, { Fragment } from 'react';
 
-import App from '../App';
-import PageHeader from '../../components/PageHeader';
-import PageBody from '../../components/PageBody';
-import PostCard from '../../components/PostCard';
-import SEO from '../../components/SEO';
+import PageHeader from 'components/PageHeader';
+import PageBody from 'components/PageBody';
+import PostCard from 'components/PostCard';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const BlogList = (props) => {
   const { data, pageContext } = props;

--- a/src/templates/Contact.js
+++ b/src/templates/Contact.js
@@ -1,11 +1,11 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import App from './App';
-import ContactContent from '../components/ContactContent';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import ContactContent from 'components/ContactContent';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const Page = (props) => {
   const { data } = props;

--- a/src/templates/Homepage.js
+++ b/src/templates/Homepage.js
@@ -1,11 +1,11 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import App from './App';
-import HomepageContent from '../components/HomepageContent';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import HomepageContent from 'components/HomepageContent';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const Page = (props) => {
   const { data } = props;

--- a/src/templates/NotFound.js
+++ b/src/templates/NotFound.js
@@ -1,13 +1,13 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import { markdown } from '../utils/markdown';
+import { markdown } from 'utils/markdown';
 
-import App from './App';
-import PageBody from '../components/PageBody';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import PageBody from 'components/PageBody';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const NotFound = (props) => {
   const { data } = props;

--- a/src/templates/Page.js
+++ b/src/templates/Page.js
@@ -1,13 +1,13 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import { markdown } from '../utils/markdown';
+import { markdown } from 'utils/markdown';
 
-import App from './App';
-import PageBody from '../components/PageBody';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import PageBody from 'components/PageBody';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const Page = (props) => {
   const { data } = props;

--- a/src/templates/Portfolio.js
+++ b/src/templates/Portfolio.js
@@ -1,13 +1,13 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import { markdown } from '../utils/markdown';
+import { markdown } from 'utils/markdown';
 
-import App from './App';
-import PageBody from '../components/PageBody';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import PageBody from 'components/PageBody';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const Portfolio = (props) => {
   const { data } = props;

--- a/src/templates/Services.js
+++ b/src/templates/Services.js
@@ -1,11 +1,11 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
-import App from './App';
-import ServicesContent from '../components/ServicesContent';
-import PageHeader from '../components/PageHeader';
-import PageWrapper from '../components/PageWrapper';
-import SEO from '../components/SEO';
+import ServicesContent from 'components/ServicesContent';
+import PageHeader from 'components/PageHeader';
+import PageWrapper from 'components/PageWrapper';
+import SEO from 'components/SEO';
+import App from 'templates/App';
 
 export const Page = (props) => {
   const { data } = props;

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -2,7 +2,7 @@ import { Heading, List, Link, PageTitle, Paragraph } from '@octopusthink/nautilu
 import React, { createElement } from 'react';
 import RehypeReact from 'rehype-react';
 
-import config from '../../data/SiteConfig';
+import config from 'data/SiteConfig';
 
 export const markdown = (htmlAst) => {
   const renderAst = new RehypeReact({


### PR DESCRIPTION
This allows you to import things relative to `src/`, the project root, and `node_modules` without using all the relative `../` in the paths.

Also fixes use of importing theme variables directly.

Fix #36.

Definitely have a quick browse-through of this one, in case there was anything exported directly from `config/theme.js` that isn't being picked up by `useTheme()`. If you notice any style regressions, basically, let me know.