### PR TITLE
fix: Inverse site and page title on the homepage only.

### DIFF
--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -10,7 +10,7 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, homepage, lang, meta, title }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -26,14 +26,18 @@ function SEO({ description, lang, meta, title }) {
   );
 
   const metaDescription = description || site.siteMetadata.description;
+  let pageTitle;
+  if (homepage) {
+    pageTitle = `${site.siteMetadata.title} · ${title}`;
+  } else {
+    pageTitle = `${title} · ${site.siteMetadata.title}`;
+  }
 
   return (
     <Helmet
       htmlAttributes={{
         lang,
       }}
-      title={title}
-      titleTemplate={`%s · ${site.siteMetadata.title}`}
       meta={[
         {
           name: `description`,
@@ -68,7 +72,9 @@ function SEO({ description, lang, meta, title }) {
           content: metaDescription,
         },
       ].concat(meta)}
-    />
+    >
+      <title>{pageTitle}</title>
+    </Helmet>
   );
 }
 

--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -10,7 +10,8 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
-function SEO({ description, homepage, lang, meta, title }) {
+function SEO(props) {
+  const { description, homepage, lang, meta, title } = props;
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -26,11 +27,9 @@ function SEO({ description, homepage, lang, meta, title }) {
   );
 
   const metaDescription = description || site.siteMetadata.description;
-  let pageTitle;
+  let pageTitle = `${title} · ${site.siteMetadata.title}`;
   if (homepage) {
     pageTitle = `${site.siteMetadata.title} · ${title}`;
-  } else {
-    pageTitle = `${title} · ${site.siteMetadata.title}`;
   }
 
   return (

--- a/src/templates/Homepage.js
+++ b/src/templates/Homepage.js
@@ -5,6 +5,8 @@ import HomepageContent from 'components/HomepageContent';
 import PageHeader from 'components/PageHeader';
 import PageWrapper from 'components/PageWrapper';
 import SEO from 'components/SEO';
+import Helmet from 'react-helmet';
+
 import App from 'templates/App';
 
 export const Page = (props) => {
@@ -15,7 +17,7 @@ export const Page = (props) => {
 
   return (
     <App>
-      <SEO title={title} description={description} />
+      <SEO title={title} description={description} homepage />
       <PageWrapper>
         <PageHeader
           pageTitle={title}

--- a/src/templates/Homepage.js
+++ b/src/templates/Homepage.js
@@ -1,13 +1,11 @@
 import { graphql } from 'gatsby';
 import React from 'react';
 
+import App from 'templates/App';
 import HomepageContent from 'components/HomepageContent';
 import PageHeader from 'components/PageHeader';
 import PageWrapper from 'components/PageWrapper';
 import SEO from 'components/SEO';
-import Helmet from 'react-helmet';
-
-import App from 'templates/App';
 
 export const Page = (props) => {
   const { data } = props;


### PR DESCRIPTION
Turns this title:

`Technology that works for you. · Octopus Think`

into:

`Octopus Think · Technology that works for you.`

on the homepage only. See #41.

It didn't look as though there was a way of controlling this using  Helmet (see https://github.com/nfl/react-helmet/issues/293), so I've just opted for doing it manually so we can have more fine-grained control.

I'm open to corrections if there's a better approach!