### PR TITLE
docs: Add basic information for local development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ octopusthink.com uses Gatsby. To run a local copy, clone the repo to your local 
 
 ```bash
 npm start
+```
 
 That's it! You can now find the site at [localhost:8000](http://localhost:8000/).
 
@@ -21,6 +22,7 @@ All pull requests must pass the linter rules to be merged into master. Tests are
 
 ````bash
 npm run lint
+```
 
 ### Using the design system
 
@@ -28,7 +30,9 @@ octopusthink.com uses the [Nautilus](https://nautilus.octopusthink.com) design s
 
 To pull the latest changes, uninstall and reinstall the Nautilus dependency:
 
-`npm uninstall nautilus && npm install --save octopusthink/nautilus`
+```bash
+npm uninstall nautilus && npm install --save octopusthink/nautilus
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ octopusthink.com uses Gatsby. To run a local copy, clone the repo to your local 
 
 `npm start`
 
-That's it! You can now find the site at [http://localhost:8000/](http://localhost:8000/). 
+That's it! You can now find the site at [localhost:8000](http://localhost:8000/).
 
-All changes you make to front-end React code and styles will immediately be loaded. Any changes to `gatbsy-config.js` require restarting the Gatsby server (`Control-C` + `npm start`.)
+All changes you make to front-end React code and styles will immediately be loaded. Any changes to `gatbsy-config.js` or `gatsby-node.js` require restarting the Gatsby server.
 
 ### Running tests
 
-All pull requests must pass both unit tests and linter rules to be merged into master. Tests are run against branches using Github actions, but you can also run tests locally:
+All pull requests must pass both unit tests and linter rules to be merged into master. Tests are run against branches using GitHub Actions, but you can also run tests locally:
 
 `npm run lint
 npm run test`
 
 ### Using the design system
 
-octopusthink.com uses the [Nautilus](https://nautilus.octopusthink.com) design system under the hood. Since Nautilus is still very much under development, it's pulling from the latest changes made to the master Github branch, rather than the published version.
+octopusthink.com uses the [Nautilus](https://nautilus.octopusthink.com) design system under the hood. Since Nautilus is still very much under development, it's pulling from the latest changes made to the `master` GitHub branch, rather than the published version.
 
 To pull the latest changes, uninstall and reinstall the Nautilus dependency:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All changes you make to front-end React code and styles will immediately be load
 
 All pull requests must pass the linter rules to be merged into master. Tests are run against branches using GitHub Actions, but you can also run tests locally:
 
-````bash
+```bash
 npm run lint
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 This is the code powering the blog and website for [Octopus Think](https://octopusthink.com/).
 
+## Development
+
+### Getting started
+
+octopusthink.com uses Gatsby. To run a local copy, clone the repo to your local machine, and start the Gatsby server:
+
+`npm start`
+
+That's it! You can now find the site at [http://localhost:8000/](http://localhost:8000/). 
+
+All changes you make to front-end React code and styles will immediately be loaded. Any changes to `gatbsy-config.js` require restarting the Gatsby server (`Control-C` + `npm start`.)
+
+### Running tests
+
+All pull requests must pass both unit tests and linter rules to be merged into master. Tests are run against branches using Github actions, but you can also run tests locally:
+
+`npm run lint
+npm run test`
+
+### Using the design system
+
+octopusthink.com uses the [Nautilus](https://nautilus.octopusthink.com) design system under the hood. Since Nautilus is still very much under development, it's pulling from the latest changes made to the master Github branch, rather than the published version.
+
+To pull the latest changes, uninstall and reinstall the Nautilus dependency:
+
+`npm uninstall nautilus && npm install --save octopusthink/nautilus`
+
 ## License
 
 Copyright (c) 2019 Octopus Think (https://octopusthink.com/)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is the code powering the blog and website for [Octopus Think](https://octop
 
 octopusthink.com uses Gatsby. To run a local copy, clone the repo to your local machine, and start the Gatsby server:
 
-`npm start`
+```bash
+npm start
 
 That's it! You can now find the site at [localhost:8000](http://localhost:8000/).
 
@@ -16,10 +17,10 @@ All changes you make to front-end React code and styles will immediately be load
 
 ### Running tests
 
-All pull requests must pass both unit tests and linter rules to be merged into master. Tests are run against branches using GitHub Actions, but you can also run tests locally:
+All pull requests must pass the linter rules to be merged into master. Tests are run against branches using GitHub Actions, but you can also run tests locally:
 
-`npm run lint
-npm run test`
+````bash
+npm run lint
 
 ### Using the design system
 


### PR DESCRIPTION
This is mostly because I keep forgetting how to uninstall/reinstall Nautilus and wind up searching Slack messages, which seems sub-optimal. The rest is just kinda good docs hygiene/reminders for my future forgetful self.