### PR TITLE
fix: Add back metadata prop to PageHeader so blog posts show dates.

### DIFF
--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -6,7 +6,7 @@ import Divider from 'components/Divider';
 import Watermark from 'static/watermark.svg';
 
 const PageHeader = (props) => {
-  const { summary, summaryExtra, title } = props;
+  const { metadata, summary, summaryExtra, title } = props;
   const theme = useTheme();
 
   return (
@@ -70,6 +70,7 @@ const PageHeader = (props) => {
             }
           `}
         >
+          {metadata}
           <PageTitle
             css={css`
               color: white;


### PR DESCRIPTION
Looks like the "metadata" prop was removed from the `PageHeader` component as part of https://github.com/octopusthink/octopusthink.com/commit/dd6ea229595c4bb4b897e49b63d4aa4879c7dca5, so metadata, like dates and tags, stopped appearing on posts. I'm guessing this wasn't on purpose, but might be worth checking out just in case,

Before:
<img width="775" alt="Screenshot 2020-01-17 at 10 22 01" src="https://user-images.githubusercontent.com/376315/72604730-63380900-3913-11ea-871b-d1a3051e0ddf.png">

After:
<img width="782" alt="Screenshot 2020-01-17 at 10 23 02" src="https://user-images.githubusercontent.com/376315/72604748-6e8b3480-3913-11ea-95b3-eddcc016db6b.png">