### PR TITLE
feat: Use larger images when sharing on Twitter.

### DIFF
--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -12,6 +12,8 @@ const config = {
   twitter: '@octopusthinks',
   copyright: `Copyright © ${new Date().getFullYear()}. Octopus Think Ltd.`, // Copyright string for the footer of the website and RSS feed.
   defaultImage: '/og-images/default.png', // Fallback image used when sharing to social sites.
+  imageHeight: '630',
+  imageWidth: '1200',
 
   // Ghost Ship Settings
   enableBlogAuthors: true,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,6 +11,8 @@ module.exports = {
   siteMetadata: {
     title: config.siteTitle,
     defaultImage: config.defaultImage,
+    imageHeight: config.imageHeight,
+    imageWidth: config.imageWidth,
     description: config.siteDescription,
     author: config.twitter,
     copyright: config.copyright,

--- a/src/components/SEO/index.js
+++ b/src/components/SEO/index.js
@@ -41,6 +41,8 @@ function SEO(props) {
             author
             defaultImage
             description
+            imageHeight
+            imageWidth
             language
             siteUrl
             title
@@ -61,6 +63,8 @@ function SEO(props) {
     description: description || site.siteMetadata.description,
     lang: lang || site.siteMetadata.language,
     image: `${site.siteMetadata.siteUrl}${image || site.siteMetadata.defaultImage}`,
+    imageHeight: site.siteMetadata.imageHeight,
+    imageWidth: site.siteMetadata.imageWidth,
     modifiedTime,
     publishedTime,
     siteName: site.siteMetadata.title,
@@ -108,6 +112,14 @@ function SEO(props) {
           property: `og:image`,
           content: seo.image,
         },
+        {
+          property: `og:image:width`,
+          content: seo.imageWidth,
+        },
+        {
+          property: `og:image:height`,
+          content: seo.imageHeight,
+        },
         outputIfSet(article && seo.publishedTime, {
           property: `article:published_time`,
           content: seo.publishedTime,
@@ -122,7 +134,7 @@ function SEO(props) {
         }),
         {
           name: `twitter:card`,
-          content: `summary`,
+          content: `summary_large_image`,
         },
         {
           name: `twitter:creator`,


### PR DESCRIPTION
This still needs me to replace our boilerplate images, if I recall correctly. (It's been sitting here a while!) I might sort this out when we're ready to post our next blog post, since I'll be working on images then. I'll put together a template file and update the default at that point.

Fix #133.